### PR TITLE
Add support for NMEA 4.10 TAG Blocks in aisnmea convenience library

### DIFF
--- a/aisnmea/nmea_test.go
+++ b/aisnmea/nmea_test.go
@@ -116,3 +116,61 @@ func TestNMEAReencode(t *testing.T) {
 	}
 
 }
+
+func TestNMEATagBlockDecodeSingleSentence(t *testing.T) {
+	nm := NMEACodecNew(ais.CodecNew(false, false))
+	msg, err := nm.ParseSentence("\\s:2156,c:1560234814*36\\!AIVDM,1,1,,B,23aDqDOP0S0:mk2Kv3Ip=wvpR>`<,0*3D")
+
+	if err != nil {
+		t.Error("Error returned for valid message", err)
+	}
+
+	if msg == nil {
+		t.Error("No error, but no message for single-sentence message")
+	}
+
+	if msg.TagBlock.Source != "2156" {
+		t.Error("TAG block Source not parsed")
+	}
+
+	if msg.TagBlock.Time != 1560234814 {
+		t.Error("TAG block Time not parsed")
+	}
+}
+
+func TestNMEATagBlockDecodeMultiSentence(t *testing.T) {
+	nm := NMEACodecNew(ais.CodecNew(false, false))
+	msg, err := nm.ParseSentence(
+		"\\g:1-2-2449555,s:2251,c:1560234814*7E\\!AIVDM,2,1,7,A,"+
+			"8h3OwjQKP@5UUEPPP121IoCol54cd0Wws7wwjp:@`P1UUFD9e2B94oCPH54M`3kw,0*7A")
+
+	if err != nil {
+		t.Error("Error returned for valid message", err)
+	}
+
+	if msg != nil {
+		t.Error("Premature return of message")
+	}
+
+	msg, err = nm.ParseSentence("\\g:2-2-2449555*63\\!AIVDM,2,2,7,A,sUwwjt;HvP1,2*4F")
+
+	if err != nil {
+		t.Error("Error returned for valid message", err)
+	}
+
+	if msg == nil {
+		t.Error("No error, but no message for message-sentence message")
+	}
+
+	if msg.TagBlock.Source != "2251" {
+		t.Error("TAG block Source not parsed")
+	}
+
+	if msg.TagBlock.Time != 1560234814 {
+		t.Error("TAG block Time not parsed")
+	}
+
+	if msg.TagBlock.Grouping != "" {
+		t.Error("TAG block Grouping parsed (should be ignored)")
+	}
+}

--- a/aisnmea/nmea_test.go
+++ b/aisnmea/nmea_test.go
@@ -159,7 +159,7 @@ func TestNMEATagBlockDecodeMultiSentence(t *testing.T) {
 	}
 
 	if msg == nil {
-		t.Error("No error, but no message for message-sentence message")
+		t.Error("No error, but no message for multi-sentence message")
 	}
 
 	if msg.TagBlock.Source != "2251" {

--- a/aisnmea/tagblocks.go
+++ b/aisnmea/tagblocks.go
@@ -1,0 +1,110 @@
+package aisnmea
+
+import (
+	"fmt"
+	"strings"
+
+	nmea "github.com/adrianmo/go-nmea"
+)
+
+// BlankTagBlock is a pseudo-constant for convenient comparisons to a blank value
+var BlankTagBlock nmea.TagBlock
+
+// addTagBlockChecksum performs the NMEA checksum from byte 0 (unlike addChecksum from nmea.go, which starts at 1)
+func addTagBlockChecksum(sentence string) string {
+	checksum := byte(0)
+	for i := 0; i < len(sentence); i++ {
+		checksum ^= sentence[i]
+	}
+
+	return fmt.Sprintf("%s*%02X", sentence, checksum)
+}
+
+/* 	mergeTagBlocks tries to summarise NMEA 4.10 TAG Blocks relating to a multi-sentence
+	VDMVDO message (src) into one (dst) upon decoding. It is neccessarily lossy.
+
+	Here are the assumptions:
+
+	- Certain tags should be never have more than one value (time, source, etc), so we pick
+      the first value, and ignore subsequent ones. If for some weird reason the sentences are
+      timestamped instead of the message, we'd want to use the earliest timestamp.
+	- The grouping tag should be different for every sentence, so there is no sense in including it.
+	- Most examples in the wild seem to send the same tag block for every sentence of a message,
+	  in those cases this function does no useful work, but no harm either.
+	- If each sentence contributes a different subset of tags, we'll get a complete set at the end.
+*/
+func mergeTagBlocks(dst *nmea.TagBlock, src *nmea.TagBlock) {
+	if dst == nil || src == nil {
+		return
+	}
+
+	if src.Time != 0 && dst.Time == 0 {
+		dst.Time = src.Time
+	}
+
+	if src.Text != "" && dst.Text == "" {
+		dst.Text = src.Text
+	}
+
+	if src.Destination != "" && dst.Destination == "" {
+		dst.Destination = src.Destination
+	}
+
+	if src.Source != "" && dst.Source == "" {
+		dst.Source = src.Source
+	}
+
+	if src.RelativeTime != 0 && dst.RelativeTime == 0 {
+		dst.RelativeTime = src.RelativeTime
+	}
+
+	if src.LineCount != 0 && dst.LineCount == 0 {
+		dst.LineCount = src.LineCount
+	}
+}
+
+// encodeTagBlock encodes the fields of tagBlock into a NMEA 4.10 TAG Block string
+func encodeTagBlock(tagBlock *nmea.TagBlock, msgIndex, msgNum, seqNo int, addLineCount bool) string {
+	if tagBlock == nil || *tagBlock == BlankTagBlock {
+		return ""
+	}
+
+	tags := []string{}
+
+	if msgNum > 1 {
+		// We add the group tag for all sentences in a multi-sentence message
+		tags = append(tags, fmt.Sprintf("g:%d-%d-%d", msgIndex, msgNum, seqNo))
+
+		// We don't duplicate the rest of the tags for subsequent sentences of multi-sentence message
+		if msgIndex > 1 {
+			return fmt.Sprintf("\\%s\\", addTagBlockChecksum(tags[0]))
+		}
+
+		// If we got this far, it is a multi-sentence message AND this is the first sentence
+		if addLineCount {
+			tags = append(tags, fmt.Sprintf("n:%d", msgNum))
+		}
+	}
+
+	if tagBlock.Source != "" {
+		tags = append(tags, fmt.Sprintf("s:%s", tagBlock.Source))
+	}
+
+	if tagBlock.Time != 0 {
+		tags = append(tags, fmt.Sprintf("c:%d", tagBlock.Time))
+	}
+
+	if tagBlock.RelativeTime != 0 {
+		tags = append(tags, fmt.Sprintf("r:%d", tagBlock.RelativeTime))
+	}
+
+	if tagBlock.Destination != "" {
+		tags = append(tags, fmt.Sprintf("d:%s", tagBlock.Destination))
+	}
+
+	if tagBlock.Text != "" {
+		tags = append(tags, fmt.Sprintf("t:%s", tagBlock.Text))
+	}
+
+	return fmt.Sprintf("\\%s\\", addTagBlockChecksum(strings.Join(tags, ",")))
+}

--- a/aisnmea/tagblocks_test.go
+++ b/aisnmea/tagblocks_test.go
@@ -1,0 +1,131 @@
+package aisnmea
+
+import "testing"
+import nmea "github.com/adrianmo/go-nmea"
+
+func Test_encodeTagBlock(t *testing.T) {
+	type args struct {
+		tagBlock *nmea.TagBlock
+		msgIndex int
+		msgNum   int
+		seqNo    int
+		addLineCount bool
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{name:"nil input tagblock", args:args{
+			tagBlock: nil, msgIndex: 0, msgNum: 0, seqNo: 0, addLineCount: true}, want:""},
+		{name:"blank input tagblock", args:args{
+			tagBlock: &nmea.TagBlock{}, msgIndex: 0, msgNum: 0, seqNo: 0, addLineCount: true}, want:""},
+		{name:"single sentence message",
+			args:args{
+				tagBlock: &nmea.TagBlock{
+					Time:         1,
+				},
+				msgIndex: 1, msgNum: 1, seqNo: 0, addLineCount: true,
+			},
+			want:"\\c:1*68\\",
+		},
+		{name:"multi sentence message, sentence 1",
+			args:args{
+				tagBlock: &nmea.TagBlock{
+					Time:         1,
+				},
+				msgIndex: 1, msgNum: 2, seqNo: 0, addLineCount: true,
+			},
+			want:"\\g:1-2-0,n:2,c:1*60\\",
+		},
+		{name:"multi sentence message, sentence 2",
+			args:args{
+				tagBlock: &nmea.TagBlock{
+					Time:         1,
+				},
+				msgIndex: 2, msgNum: 2, seqNo: 0, addLineCount: true,
+			},
+			want:"\\g:2-2-0*6D\\",
+		},
+		{name:"correct checksum time source and grouping",
+			args:args{
+				tagBlock: &nmea.TagBlock{
+					Time:         1560234814,
+					Source:       "2251",
+					Grouping:     "1-2-2449555",
+				},
+				msgIndex: 1, msgNum: 2, seqNo: 2449555, addLineCount: false,
+			},
+			want:"\\g:1-2-2449555,s:2251,c:1560234814*7E\\",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := encodeTagBlock(
+				tt.args.tagBlock, tt.args.msgIndex, tt.args.msgNum, tt.args.seqNo, tt.args.addLineCount);
+			got != tt.want {
+				t.Errorf("encodeTagBlock() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_mergeTagBlocks(t *testing.T) {
+	type args struct {
+		dst *nmea.TagBlock
+		src *nmea.TagBlock
+	}
+	tests := []struct {
+		name string
+		args args
+		ok func(t *testing.T, a args)
+	}{
+		{name:"null src", args:args{dst:&nmea.TagBlock{Text: "foo"}, src:nil}, ok:func(t *testing.T, a args) {
+			same := nmea.TagBlock{Text: "foo"}
+			if *a.dst != same {
+				t.Error("null src is expected to leave dst unchanged")
+			}
+		}},
+		{name:"null dst", args:args{src:&nmea.TagBlock{Text: "foo"}, dst:nil}, ok:func(t *testing.T, a args) {
+			if a.dst != nil {
+				t.Error("null dst is expected to remain unchanged")
+			}
+		}},
+		{name:"zero src time", args:args{src:&nmea.TagBlock{Time: 0}, dst:&nmea.TagBlock{Time: 1}},
+			ok:func(t *testing.T, a args) {
+				if a.dst.Time != 1 {
+					t.Error("zero src time should not overwrite dst time")
+				}
+		}},
+		{name:"non-zero dst time", args:args{src:&nmea.TagBlock{Time: 2}, dst:&nmea.TagBlock{Time: 1}},
+			ok:func(t *testing.T, a args) {
+				if a.dst.Time != 1 {
+					t.Error("non-zero dst time should remain unchanged")
+				}
+		}},
+		{name:"orthogonal tags", args:args{src:&nmea.TagBlock{Source: "outer_space"}, dst:&nmea.TagBlock{Time: 1}},
+			ok:func(t *testing.T, a args) {
+				if a.dst.Time != 1 {
+					t.Error("time not set")
+				}
+				if a.dst.Source != "outer_space" {
+					t.Error("source not set")
+				}
+		}},
+		{name:"ignore grouping tag", args:args{src:&nmea.TagBlock{Grouping: "1-2-99"}, dst:&nmea.TagBlock{Time: 1}},
+			ok:func(t *testing.T, a args) {
+				if a.dst.Time != 1 {
+					t.Error("dst time should remain unchanged")
+				}
+				if a.dst.Grouping != "" {
+					t.Error("dst grouping should never be set")
+				}
+		}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			mergeTagBlocks(tt.args.dst, tt.args.src)
+			tt.ok(t, tt.args)
+		})
+	}
+}

--- a/aisnmea/tagblocks_test.go
+++ b/aisnmea/tagblocks_test.go
@@ -5,10 +5,10 @@ import nmea "github.com/adrianmo/go-nmea"
 
 func Test_encodeTagBlock(t *testing.T) {
 	type args struct {
-		tagBlock *nmea.TagBlock
-		msgIndex int
-		msgNum   int
-		seqNo    int
+		tagBlock     *nmea.TagBlock
+		msgIndex     int
+		msgNum       int
+		seqNo        int
 		addLineCount bool
 	}
 	tests := []struct {
@@ -16,54 +16,53 @@ func Test_encodeTagBlock(t *testing.T) {
 		args args
 		want string
 	}{
-		{name:"nil input tagblock", args:args{
-			tagBlock: nil, msgIndex: 0, msgNum: 0, seqNo: 0, addLineCount: true}, want:""},
-		{name:"blank input tagblock", args:args{
-			tagBlock: &nmea.TagBlock{}, msgIndex: 0, msgNum: 0, seqNo: 0, addLineCount: true}, want:""},
-		{name:"single sentence message",
-			args:args{
+		{name: "nil input tagblock", args: args{
+			tagBlock: nil, msgIndex: 0, msgNum: 0, seqNo: 0, addLineCount: true}, want: ""},
+		{name: "blank input tagblock", args: args{
+			tagBlock: &nmea.TagBlock{}, msgIndex: 0, msgNum: 0, seqNo: 0, addLineCount: true}, want: ""},
+		{name: "single sentence message",
+			args: args{
 				tagBlock: &nmea.TagBlock{
-					Time:         1,
+					Time: 1,
 				},
 				msgIndex: 1, msgNum: 1, seqNo: 0, addLineCount: true,
 			},
-			want:"\\c:1*68\\",
+			want: "\\c:1*68\\",
 		},
-		{name:"multi sentence message, sentence 1",
-			args:args{
+		{name: "multi sentence message, sentence 1",
+			args: args{
 				tagBlock: &nmea.TagBlock{
-					Time:         1,
+					Time: 1,
 				},
 				msgIndex: 1, msgNum: 2, seqNo: 0, addLineCount: true,
 			},
-			want:"\\g:1-2-0,n:2,c:1*60\\",
+			want: "\\g:1-2-0,n:2,c:1*60\\",
 		},
-		{name:"multi sentence message, sentence 2",
-			args:args{
+		{name: "multi sentence message, sentence 2",
+			args: args{
 				tagBlock: &nmea.TagBlock{
-					Time:         1,
+					Time: 1,
 				},
 				msgIndex: 2, msgNum: 2, seqNo: 0, addLineCount: true,
 			},
-			want:"\\g:2-2-0*6D\\",
+			want: "\\g:2-2-0*6D\\",
 		},
-		{name:"correct checksum time source and grouping",
-			args:args{
+		{name: "correct checksum time source and grouping",
+			args: args{
 				tagBlock: &nmea.TagBlock{
-					Time:         1560234814,
-					Source:       "2251",
-					Grouping:     "1-2-2449555",
+					Time:     1560234814,
+					Source:   "2251",
+					Grouping: "1-2-2449555",
 				},
 				msgIndex: 1, msgNum: 2, seqNo: 2449555, addLineCount: false,
 			},
-			want:"\\g:1-2-2449555,s:2251,c:1560234814*7E\\",
+			want: "\\g:1-2-2449555,s:2251,c:1560234814*7E\\",
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := encodeTagBlock(
-				tt.args.tagBlock, tt.args.msgIndex, tt.args.msgNum, tt.args.seqNo, tt.args.addLineCount);
-			got != tt.want {
+				tt.args.tagBlock, tt.args.msgIndex, tt.args.msgNum, tt.args.seqNo, tt.args.addLineCount); got != tt.want {
 				t.Errorf("encodeTagBlock() = %v, want %v", got, tt.want)
 			}
 		})
@@ -78,49 +77,49 @@ func Test_mergeTagBlocks(t *testing.T) {
 	tests := []struct {
 		name string
 		args args
-		ok func(t *testing.T, a args)
+		ok   func(t *testing.T, a args)
 	}{
-		{name:"null src", args:args{dst:&nmea.TagBlock{Text: "foo"}, src:nil}, ok:func(t *testing.T, a args) {
+		{name: "null src", args: args{dst: &nmea.TagBlock{Text: "foo"}, src: nil}, ok: func(t *testing.T, a args) {
 			same := nmea.TagBlock{Text: "foo"}
 			if *a.dst != same {
 				t.Error("null src is expected to leave dst unchanged")
 			}
 		}},
-		{name:"null dst", args:args{src:&nmea.TagBlock{Text: "foo"}, dst:nil}, ok:func(t *testing.T, a args) {
+		{name: "null dst", args: args{src: &nmea.TagBlock{Text: "foo"}, dst: nil}, ok: func(t *testing.T, a args) {
 			if a.dst != nil {
 				t.Error("null dst is expected to remain unchanged")
 			}
 		}},
-		{name:"zero src time", args:args{src:&nmea.TagBlock{Time: 0}, dst:&nmea.TagBlock{Time: 1}},
-			ok:func(t *testing.T, a args) {
+		{name: "zero src time", args: args{src: &nmea.TagBlock{Time: 0}, dst: &nmea.TagBlock{Time: 1}},
+			ok: func(t *testing.T, a args) {
 				if a.dst.Time != 1 {
 					t.Error("zero src time should not overwrite dst time")
 				}
-		}},
-		{name:"non-zero dst time", args:args{src:&nmea.TagBlock{Time: 2}, dst:&nmea.TagBlock{Time: 1}},
-			ok:func(t *testing.T, a args) {
+			}},
+		{name: "non-zero dst time", args: args{src: &nmea.TagBlock{Time: 2}, dst: &nmea.TagBlock{Time: 1}},
+			ok: func(t *testing.T, a args) {
 				if a.dst.Time != 1 {
 					t.Error("non-zero dst time should remain unchanged")
 				}
-		}},
-		{name:"orthogonal tags", args:args{src:&nmea.TagBlock{Source: "outer_space"}, dst:&nmea.TagBlock{Time: 1}},
-			ok:func(t *testing.T, a args) {
+			}},
+		{name: "orthogonal tags", args: args{src: &nmea.TagBlock{Source: "outer_space"}, dst: &nmea.TagBlock{Time: 1}},
+			ok: func(t *testing.T, a args) {
 				if a.dst.Time != 1 {
 					t.Error("time not set")
 				}
 				if a.dst.Source != "outer_space" {
 					t.Error("source not set")
 				}
-		}},
-		{name:"ignore grouping tag", args:args{src:&nmea.TagBlock{Grouping: "1-2-99"}, dst:&nmea.TagBlock{Time: 1}},
-			ok:func(t *testing.T, a args) {
+			}},
+		{name: "ignore grouping tag", args: args{src: &nmea.TagBlock{Grouping: "1-2-99"}, dst: &nmea.TagBlock{Time: 1}},
+			ok: func(t *testing.T, a args) {
 				if a.dst.Time != 1 {
 					t.Error("dst time should remain unchanged")
 				}
 				if a.dst.Grouping != "" {
 					t.Error("dst grouping should never be set")
 				}
-		}},
+			}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Hi Bertold!

We recently worked with the `go-nmea` maintainers to get an earlier PR merged to add NMEA 4.10 TAG Blocks support: https://github.com/adrianmo/go-nmea/pull/78

This PR adds support for:
- Accessing the TAG Blocks info (which `go-nmea` now handles) via the `aisnmea.VdmPacket` struct (including some logic to merge tags from multi-sentence messages into one struct).
- Encoding the values from the same struct into NMEA sentences (but only if they are not blank values, so if you don't touch that struct, you'll get un-tagged NMEA sentences, hence no change for existing applications that use `go-ais`)

I have added unit tests for the TAG Block processing code and two tests for checking that end-to-end decoding still works. The existing unit tests still pass, so I don't think this PR breaks anything.

Thanks for `go-ais`, and please let me know if you have any questions, concerns or desire any changes to get this PR accepted.

Regards,
Simeon.