### PR TITLE
Update all tests to use the right constructor

### DIFF
--- a/aisnmea/nmea_test.go
+++ b/aisnmea/nmea_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestWrongType(t *testing.T) {
-	nm := NMEACodecNew(ais.CodecNew(false, false, false))
+	nm := NMEACodecNew(ais.CodecNew(false, false))
 	_, err := nm.ParseSentence("$GPRMC,123519,A,4807.038,N,01131.000,E,022.4,084.4,230394,003.1,W*6A")
 
 	if err.Error() != SentenceNotVDMVDO {
@@ -22,7 +22,7 @@ func TestWrongType(t *testing.T) {
 }
 
 func TestInvalid(t *testing.T) {
-	nm := NMEACodecNew(ais.CodecNew(false, false, false))
+	nm := NMEACodecNew(ais.CodecNew(false, false))
 	_, err := nm.ParseSentence("$Not a NMEA sentence*bb")
 
 	if err == nil {
@@ -31,7 +31,7 @@ func TestInvalid(t *testing.T) {
 }
 
 func TestTooManyFragments(t *testing.T) {
-	nm := NMEACodecNew(ais.CodecNew(false, false, false))
+	nm := NMEACodecNew(ais.CodecNew(false, false))
 	_, err := nm.ParseSentence("!AIVDM,30,1,,A,13u08p0000QDeLNO=PvHU3M>0>`<,0*32")
 
 	if err != nil {
@@ -44,7 +44,7 @@ func TestTooManyFragments(t *testing.T) {
 }
 
 func TestFailedEncode(t *testing.T) {
-	nm := NMEACodecNew(ais.CodecNew(false, false, false))
+	nm := NMEACodecNew(ais.CodecNew(false, false))
 
 	p := VdmPacket{}
 
@@ -62,8 +62,8 @@ func TestFailedEncode(t *testing.T) {
 }
 
 func TestNMEAReencode(t *testing.T) {
-	nm := NMEACodecNew(ais.CodecNew(false, false, false))
-	nm2 := NMEACodecNew(ais.CodecNew(false, false, false))
+	nm := NMEACodecNew(ais.CodecNew(false, false))
+	nm2 := NMEACodecNew(ais.CodecNew(false, false))
 
 	file, err := os.Open("testdata/aistest.nmea")
 	if err != nil {
@@ -118,7 +118,7 @@ func TestNMEAReencode(t *testing.T) {
 }
 
 func TestNMEATagBlockDecodeSingleSentence(t *testing.T) {
-	nm := NMEACodecNew(ais.CodecNew(false, false, false))
+	nm := NMEACodecNew(ais.CodecNew(false, false))
 	msg, err := nm.ParseSentence("\\s:2156,c:1560234814*36\\!AIVDM,1,1,,B,23aDqDOP0S0:mk2Kv3Ip=wvpR>`<,0*3D")
 
 	if err != nil {
@@ -139,7 +139,7 @@ func TestNMEATagBlockDecodeSingleSentence(t *testing.T) {
 }
 
 func TestNMEATagBlockDecodeMultiSentence(t *testing.T) {
-	nm := NMEACodecNew(ais.CodecNew(false, false, false))
+	nm := NMEACodecNew(ais.CodecNew(false, false))
 	msg, err := nm.ParseSentence(
 		"\\g:1-2-2449555,s:2251,c:1560234814*7E\\!AIVDM,2,1,7,A," +
 			"8h3OwjQKP@5UUEPPP121IoCol54cd0Wws7wwjp:@`P1UUFD9e2B94oCPH54M`3kw,0*7A")

--- a/bench_decode_test.go
+++ b/bench_decode_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func runTest(b *testing.B, parseFast bool) {
-	x := ais.CodecNew(false, false, parseFast)
+	x := ais.CodecNewFast(false, false, parseFast)
 	line := "000001000011100000000111101001010010000000000000000000000000011111110111110111001101001000100000111001110001011110001000101011000101000111011110000000001110101000001100"
 	source := []byte(line)
 	/* Convert ascii '0' and '1' to real 0 and 1 */
@@ -33,7 +33,7 @@ func BenchmarkDecode(b *testing.B) {
 }
 
 func readFileTest(b *testing.B, benchFile string, parseFast bool) {
-	c := ais.CodecNew(false, false, parseFast)
+	c := ais.CodecNewFast(false, false, parseFast)
 	nm := aisnmea.NMEACodecNew(c)
 	var reader io.Reader
 	fp, err := os.Open(benchFile)

--- a/decode_fail_test.go
+++ b/decode_fail_test.go
@@ -3,7 +3,7 @@ package ais
 import "testing"
 
 func TestDecodeFailMsgIDTooShort(t *testing.T) {
-	x := CodecNew(false, false, false)
+	x := CodecNew(false, false)
 
 	data := []byte{0, 1, 0, 1}
 
@@ -15,7 +15,7 @@ func TestDecodeFailMsgIDTooShort(t *testing.T) {
 func TestDecodeStrictAlignment(t *testing.T) {
 	data := []byte{0, 0, 1, 0, 1, 0, 0, 1, 1, 0, 0, 1, 0, 1, 1, 1, 1, 0, 1, 0, 0, 0, 1, 1, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 1, 0, 1, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0}
 
-	x := CodecNew(false, false, false)
+	x := CodecNew(false, false)
 	x.StrictByteAlignment = true
 
 	if x.DecodePacket(data) == nil {
@@ -32,7 +32,7 @@ func TestDecodeStrictAlignment(t *testing.T) {
 func TestDecodeDependentBitNotReceived(t *testing.T) {
 	data := []byte{0, 1, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 1, 1, 0, 0, 1, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 1, 1, 1, 1, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 1, 0, 1, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 1, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 0, 1, 0, 0, 0, 0, 1, 1, 0, 1, 0, 1, 0, 0, 0, 0, 0, 1, 1, 1, 0, 0, 0, 0, 1, 1, 0, 1, 0, 1, 0, 1, 0, 1, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}
 
-	x := CodecNew(false, false, false)
+	x := CodecNew(false, false)
 
 	if x.DecodePacket(data) == nil {
 		t.Error("Failed to decode valid packet")

--- a/deep_compare_archive_test.go
+++ b/deep_compare_archive_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func readAllPackets(t *testing.T, benchFile string, parseFast bool, cb func(eachPacket *aisnmea.VdmPacket)) {
-	c := ais.CodecNew(false, false, parseFast)
+	c := ais.CodecNewFast(false, false, parseFast)
 	nm := aisnmea.NMEACodecNew(c)
 	var reader io.Reader
 	fp, err := os.Open(benchFile)

--- a/encode_fail_test.go
+++ b/encode_fail_test.go
@@ -3,7 +3,7 @@ package ais
 import "testing"
 
 func tryEncodeTooLong(len int) bool {
-	x := CodecNew(false, false, false)
+	x := CodecNew(false, false)
 
 	packet := SingleSlotBinaryMessage{
 		Valid:              true,
@@ -31,7 +31,7 @@ func TestEncodeFailTooLong(t *testing.T) {
 }
 
 func tryEncodeWithString(s string) bool {
-	x := CodecNew(false, false, false)
+	x := CodecNew(false, false)
 
 	packet := SafetyBroadcastMessage{
 		Valid: true,
@@ -87,7 +87,7 @@ func TestEncodeNumberTooLarge(t *testing.T) {
 }
 
 func TestEncodeFailNoUsefulData(t *testing.T) {
-	x := CodecNew(false, false, false)
+	x := CodecNew(false, false)
 
 	packet := BinaryAcknowledge{
 		Valid: true,
@@ -109,7 +109,7 @@ func TestEncodeFailNoUsefulData(t *testing.T) {
 }
 
 func tryEncodeWithMessageID(mID uint8) bool {
-	x := CodecNew(false, false, false)
+	x := CodecNew(false, false)
 
 	packet := PositionReport{
 		Valid: true,
@@ -149,7 +149,7 @@ func TestEncodeFailWrongMsgID(t *testing.T) {
 }
 
 func tryEncodeTooLargeNumber(number uint16) bool {
-	x := CodecNew(false, false, false)
+	x := CodecNew(false, false)
 
 	packet := ShipStaticData{
 		Valid: true,
@@ -183,7 +183,7 @@ func TestEncodeFloatOutOfRange(t *testing.T) {
 		UserID:    1337,
 	}
 
-	x := CodecNew(false, false, false)
+	x := CodecNew(false, false)
 	if x.EncodePacket(staticData) != nil {
 		t.Error("Encoded oversized float")
 	}

--- a/fast_parse_test.go
+++ b/fast_parse_test.go
@@ -9,11 +9,11 @@ import (
 )
 
 func TestPositionParse(t *testing.T) {
-	fastParse := CodecNew(false, false, true)
+	fastParse := CodecNewFast(false, false, true)
 	/* Convenience conversion disabled to avoid float inaccuracies */
 	fastParse.FloatWithoutConversion = true
 
-	slowParse := CodecNew(false, false, false)
+	slowParse := CodecNewFast(false, false, false)
 	slowParse.FloatWithoutConversion = true
 
 	for msgID := 1; msgID <= 27; msgID++ {

--- a/frequency_test.go
+++ b/frequency_test.go
@@ -18,7 +18,7 @@ func TestChannelToFrequency(t *testing.T) {
 		{11111, 0}, /* A channel that does not exist */
 	}
 
-	x := CodecNew(false, false, false)
+	x := CodecNew(false, false)
 
 	for _, v := range values {
 		myFreq := x.ChannelToFrequency(v.channel)

--- a/reencode_test.go
+++ b/reencode_test.go
@@ -56,7 +56,7 @@ func tryFile(t *testing.T, x *Codec, msgID int) {
 }
 
 func TestReEncode(t *testing.T) {
-	x := CodecNew(false, false, false)
+	x := CodecNew(false, false)
 
 	/* Convenience conversion disabled to avoid float inaccuracies */
 	x.FloatWithoutConversion = true
@@ -78,7 +78,7 @@ func checkFloat(a float64, b float64) bool {
 }
 
 func TestFloatReEncoder(t *testing.T) {
-	x := CodecNew(true, true, false)
+	x := CodecNew(true, true)
 	x.DecoderCheckFixedValues = true
 
 	packet := PositionReport{
@@ -135,7 +135,7 @@ func TestFloatReEncoder(t *testing.T) {
 }
 
 func testInterfacecInternal(p Packet, t *testing.T) (bool, int, uint32) {
-	x := CodecNew(false, false, false)
+	x := CodecNew(false, false)
 
 	encoded := x.EncodePacket(p)
 	if encoded == nil {
@@ -198,7 +198,7 @@ func TestInterfaceAccess(t *testing.T) {
 }
 
 func testEmptyArray(t *testing.T, slotValid bool) bool {
-	x := CodecNew(true, true, false)
+	x := CodecNew(true, true)
 
 	packet := BinaryAcknowledge{
 		Valid: true,
@@ -245,7 +245,7 @@ func TestEmptyPayloadInArrayMessages(t *testing.T) {
 }
 
 func testValidateFailCorrupt(t *testing.T, corruptSpare bool, packetType bool) bool {
-	x := CodecNew(true, true, false)
+	x := CodecNew(true, true)
 	x.DecoderCheckFixedValues = true
 
 	if !packetType {


### PR DESCRIPTION
In 395d1ecdab441b1ad7b728cadc69f4dfb49dcd6f, the CodecNew constructor was reverted to only take two booleans, and a new CodecNewFast with an option for fast parsing was added.

That caused all tests to fail with:

    ..._test.go:16:48: too many arguments in call to ais.CodecNew
        have (bool, bool, bool)
        want (bool, bool)

Update them to use the right constructor depending on their needs.