### PR TITLE
Allow invalid PartNumber in non-checked mode

### DIFF
--- a/codec.go
+++ b/codec.go
@@ -280,14 +280,16 @@ func (t *Codec) aisFillMessage(val reflect.Value, payload []byte, offset *uint) 
 			checkValue := false
 			correctValue := int64(0)
 
-			encodeAsStr, encodeAsFound := st.Field(i).Tag.Lookup("aisCheckValue")
-			if !encodeAsFound && t.DecoderCheckFixedValues {
-				encodeAsStr, encodeAsFound = st.Field(i).Tag.Lookup("aisEncodeAs")
-			}
+			if t.DecoderCheckFixedValues {
+				encodeAsStr, encodeAsFound := st.Field(i).Tag.Lookup("aisCheckValue")
+				if !encodeAsFound {
+					encodeAsStr, encodeAsFound = st.Field(i).Tag.Lookup("aisEncodeAs")
+				}
 
-			if encodeAsFound {
-				correctValue, _ = strconv.ParseInt(encodeAsStr, 10, 64)
-				checkValue = true
+				if encodeAsFound {
+					correctValue, _ = strconv.ParseInt(encodeAsStr, 10, 64)
+					checkValue = true
+				}
 			}
 
 			basicValue = extractNumber(payload, isSigned(field), offset, v)

--- a/decode_test.go
+++ b/decode_test.go
@@ -1,0 +1,41 @@
+package ais
+
+import "testing"
+
+func TestDecodeInvalidType24PartNumber(t *testing.T) {
+	// The allowed range of type 24 PartNumber is 0-1, but the field
+	// occupies two bits. The extra bit is reserved, and must be zero.
+
+	// Below is a type 24B message from this real-world NMEA:
+	// !AIVDM,1,1,,A,HTRBMh>T<wwFj443@24?pJKt00p0,0*7a
+	// The reserved bit of PartNumber is set, and message used to be rejected.
+	data := []byte{
+		0, 1, 1, 0, 0, 0, 1, 0, 0, 1, 0, 0, 1, 0, 0, 0, 1, 0, 0, 1,
+		0, 0, 1, 0, 0, 1, 1, 1, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 1, 1,
+		1, 0, 1, 0, 0, 1, 0, 0, 0, 0, 1, 1, 0, 0, 1, 1, 1, 1, 1, 1,
+		1, 1, 1, 1, 1, 1, 0, 1, 0, 1, 1, 0, 1, 1, 0, 0, 1, 0, 0, 0,
+		0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0,
+		0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 1, 1, 1,
+		1, 1, 1, 0, 0, 0, 0, 1, 1, 0, 1, 0, 0, 1, 1, 0, 1, 1, 1, 1,
+		1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 0,
+		0, 0, 0, 0, 0, 0, 0, 0,
+	}
+
+	x := CodecNew(false, false)
+	msg := x.DecodePacket(data)
+	if msg == nil {
+		t.Fatal("Failed to decode valid packet")
+	}
+	report, ok := msg.(StaticDataReport)
+	if !ok {
+		t.Fatal("Unexpected dynamic type")
+	}
+
+	// Check that reserved and part number are properly decoded.
+	if report.Reserved != 1 {
+		t.Error("Unexpected Reserved:", report.Reserved)
+	}
+	if !report.PartNumber {
+		t.Error("Unexpected PartNumber:", report.PartNumber)
+	}
+}


### PR DESCRIPTION
Before this patch, go-ais would fail to decode type 24 messages where the reserved bit was set.

Judging from the surrounding code it looks like Spare and Reserved validation is supposed to be turned off unless DecoderCheckFixedValues is true. StaticDataReport.Reserved is the only user of the aisCheckValue tag, which might explain why this doesn't fail more widely.

Guard all aisCheckValue and aisEncodeAs tag lookup, value parsing and validation by DecoderCheckFixedValues.